### PR TITLE
Add search, shiki highlighting, and reading UI

### DIFF
--- a/application/CLAUDE.md
+++ b/application/CLAUDE.md
@@ -48,36 +48,45 @@ application/
 ├── app/
 │   ├── layout.tsx              # Root layout: sidebar + header + children
 │   ├── page.tsx                # Home: hero + season grids
+│   ├── globals.css             # Tailwind base + .shiki styling + .author-link
 │   ├── error.tsx               # Error boundary (client component)
 │   ├── robots.ts               # robots.txt metadata
 │   ├── sitemap.ts              # Dynamic sitemap from getAllChapters()
 │   ├── opengraph-image.tsx     # OG image (amber bar + title)
 │   └── chapters/[slug]/
-│       ├── page.tsx            # Episode/concept page with TOC + nav
+│       ├── page.tsx            # Episode/concept page with TOC + nav + ReadingProgress
 │       ├── loading.tsx         # Skeleton loading state
 │       └── not-found.tsx       # 404 for bad slugs
 ├── components/
 │   ├── sidebar.tsx             # Server wrapper — calls getSeasons()
 │   ├── sidebar-client.tsx      # Client: collapsible nav, mobile overlay
-│   ├── header.tsx              # Sticky header with GitHub star count
-│   ├── markdown-renderer.tsx   # react-markdown with custom styled components
+│   ├── header.tsx              # Sticky header with GitHub star count + SearchTrigger
+│   ├── markdown-renderer.tsx   # Async RSC: Shiki-highlighted react-markdown
 │   ├── table-of-contents.tsx   # Client: sticky TOC with intersection observer
-│   └── chapter-nav.tsx         # Prev/Next episode links
+│   ├── chapter-nav.tsx         # Prev/Next episode links
+│   ├── copy-button.tsx         # 'use client' — copy-to-clipboard for code blocks
+│   ├── reading-progress.tsx    # 'use client' — amber scroll progress bar (chapter pages only)
+│   ├── search-modal.tsx        # 'use client' — Fuse.js search modal (fetch + fuzzy search)
+│   └── search-trigger.tsx      # 'use client' — search icon button + `/` global shortcut
 ├── lib/
 │   ├── chapters.ts             # ALL content parsing — the core of the app
 │   ├── github.ts               # Fetches GitHub star count (cached 1h)
 │   └── utils.ts                # cn() utility (clsx + tailwind-merge)
 ├── types/
 │   └── chapter.ts              # Chapter, ChapterMeta, Season, TocHeading interfaces
+├── scripts/
+│   └── generate-search-index.mjs  # Node script: writes public/search-index.json
 └── public/
-    └── icon.svg                # Favicon (JS amber + black)
+    ├── icon.svg                # Favicon (JS amber + black)
+    └── search-index.json       # 26-entry search index (auto-generated at prebuild — do not edit)
 ```
 
 ### Key exported functions from `lib/chapters.ts`
 
 - `getAllChapters(): ChapterMeta[]` — flat list of all 26 chapters in order
-- `getChapterBySlug(slug: string): Chapter | null` — full chapter with content + headings
+- `getChapterBySlug(slug: string): Chapter | null` — full chapter with content + headings + readTime
 - `getSeasons(): Season[]` — 3 seasons with nested chapter lists
+- `getSearchIndex()` — flat list of `{ slug, title, number, seasonLabel }` for all 26 chapters (used by the search index script)
 
 ### Slug format
 
@@ -85,10 +94,30 @@ application/
 - Season 2: `s2-ep01-callback-hell`, …
 - Concepts: `concepts-debouncing`, `concepts-throtling`
 
+## Data types
+
+### `Chapter` interface (`types/chapter.ts`)
+```ts
+{
+  slug: string
+  dirName: string
+  title: string
+  number: string        // "EP 01", "S2 EP 01", or "Concept"
+  season: 1 | 2 | 3
+  seasonLabel: string   // "Season 1", "Season 2", "Concepts"
+  content: string       // Full markdown content
+  headings: TocHeading[]
+  readTime: number      // Minutes to read, computed at build time (ceil(words/200))
+}
+```
+
+### `ChapterMeta` type
+`Omit<Chapter, 'content' | 'headings' | 'readTime'>` — used in sidebar and home page; does NOT include content, headings, or readTime.
+
 ## Design system
 
 - **Framework**: Tailwind CSS 3 with custom config in `tailwind.config.js`
-- **Accent color**: `#E8A000` (JavaScript amber) — used for sidebar active states, code block left borders, focus outlines
+- **Accent color**: `#E8A000` (JavaScript amber) — used for sidebar active states, code block left borders, focus outlines, reading progress bar
 - **Background**: `#FFFFFF`, **Foreground**: `#000000`
 - **Fonts** (via `next/font/google`):
   - Heading: Playfair Display (`--font-heading`)
@@ -96,15 +125,44 @@ application/
   - Mono: JetBrains Mono (`--font-mono`)
 - **No border-radius, no box-shadow** — everything is sharp-cornered by design (set to `0` in Tailwind config)
 
-## Commands
+## Dependencies (notable)
+
+| Package | Purpose |
+|---------|---------|
+| `react-markdown` | Markdown → React rendering pipeline |
+| `remark-gfm` | GitHub-flavored markdown (tables, strikethrough, etc.) |
+| `rehype-slug` | Auto anchor IDs on headings |
+| `rehype-raw` | Allows raw HTML output from Shiki to pass through react-markdown |
+| `shiki` | Build-time syntax highlighting via `codeToHtml()` |
+| `fuse.js` | Client-side fuzzy search in `SearchModal` |
+| `lucide-react` | Icons (Github, Star, Search, etc.) |
+
+Note: `@shikijs/rehype` is installed but NOT used — see "Do not" below.
+
+## Build scripts
 
 ```bash
 # From application/ directory
 npm run dev       # Start dev server at localhost:3000
-npm run build     # Production build (generates all 26 static pages)
+npm run build     # Runs prebuild (search index) then Next.js build (32 static pages)
 npm start         # Serve production build
 npm run lint      # ESLint
 ```
+
+The `prebuild` script runs `node scripts/generate-search-index.mjs`, which writes `public/search-index.json` from the chapter directories. This must run before the build so the search JSON is available to be served statically.
+
+## Syntax highlighting — how it works
+
+`MarkdownRenderer` is an **async** React Server Component. Before rendering, it pre-processes the markdown string with `codeToHtml()` from Shiki (theme: `github-light`), replacing fenced code blocks with highlighted HTML wrapped in `<div data-shiki>`. The `rehype-raw` plugin allows this HTML to pass through the react-markdown pipeline. The `div` renderer in `components` detects `data-shiki` and wraps the output with the amber left border + `CopyButton`.
+
+The `.shiki` CSS class in `globals.css` overrides Shiki's default background to `#fafafa`.
+
+## Search — how it works
+
+- At `prebuild`, `scripts/generate-search-index.mjs` writes `public/search-index.json` (26 entries with slug, title, number, seasonLabel).
+- `SearchTrigger` (in header) listens for the `/` key globally and manages open state.
+- `SearchModal` fetches `/search-index.json` once on open, initialises Fuse.js, and searches as the user types.
+- Keyboard: `↑`/`↓` to move, `Enter` to navigate, `Esc` to close.
 
 ## Sister app
 
@@ -117,3 +175,5 @@ This app is modelled after `Namaste-Nodejs/application/`. When making structural
 - Do NOT add rounded corners or box shadows — the design is intentionally sharp
 - Do NOT change the slug format — slugs are stable URLs; changing them breaks bookmarks
 - Do NOT add `Co-Authored-By: Claude` to commits in this repo
+- Do NOT use `@shikijs/rehype` as a rehype plugin in the `react-markdown` pipeline — it is async and will crash with `` `runSync` finished async ``. Use Shiki's `codeToHtml()` directly to pre-process the markdown string before rendering
+- Do NOT edit `public/search-index.json` manually — it is auto-generated by `scripts/generate-search-index.mjs` on every build

--- a/application/app/chapters/[slug]/page.tsx
+++ b/application/app/chapters/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { getAllChapters, getChapterBySlug } from '@/lib/chapters'
 import { MarkdownRenderer } from '@/components/markdown-renderer'
 import { TableOfContents } from '@/components/table-of-contents'
 import { ChapterNav } from '@/components/chapter-nav'
+import { ReadingProgress } from '@/components/reading-progress'
 
 export function generateStaticParams() {
   const chapters = getAllChapters()
@@ -43,11 +44,18 @@ export default async function ChapterPage({
     currentIndex < allChapters.length - 1 ? allChapters[currentIndex + 1] : null
 
   return (
+    <>
+      <ReadingProgress />
     <div className="max-w-6xl mx-auto px-6 md:px-12 py-16 md:py-24">
       <header className="mb-12">
-        <span className="font-mono text-xs tracking-widest uppercase text-muted-foreground">
-          {chapter.seasonLabel} &mdash; {chapter.number}
-        </span>
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-xs tracking-widest uppercase text-muted-foreground">
+            {chapter.seasonLabel} &mdash; {chapter.number}
+          </span>
+          <span className="font-mono text-[10px] tracking-widest text-muted-foreground">
+            ~ {chapter.readTime} min read
+          </span>
+        </div>
         <h1 className="font-heading text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-black tracking-tight mt-3 leading-tight">
           {chapter.title}
         </h1>
@@ -69,5 +77,6 @@ export default async function ChapterPage({
       <div className="h-1 bg-foreground mt-16 mb-8" />
       <ChapterNav prev={prev} next={next} />
     </div>
+    </>
   )
 }

--- a/application/app/globals.css
+++ b/application/app/globals.css
@@ -61,4 +61,17 @@
       animation: none;
     }
   }
+
+  /* Shiki syntax highlighting — preserve our design system */
+  .shiki {
+    @apply mb-0 overflow-x-auto text-sm leading-7;
+    background-color: #fafafa !important;
+  }
+
+  .shiki code {
+    font-family: var(--font-mono), ui-monospace, monospace;
+    background: transparent !important;
+    border: none !important;
+    padding: 0 !important;
+  }
 }

--- a/application/components/copy-button.tsx
+++ b/application/components/copy-button.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { useState } from 'react'
+
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="absolute top-3 right-3 font-mono text-[10px] tracking-widest uppercase px-2 py-1 border border-border-light bg-background hover:bg-foreground hover:text-background transition-colors duration-100"
+      aria-label="Copy code"
+    >
+      {copied ? 'Copied ✓' : 'Copy'}
+    </button>
+  )
+}

--- a/application/components/header.tsx
+++ b/application/components/header.tsx
@@ -1,4 +1,5 @@
 import { Github, Star } from 'lucide-react'
+import { SearchTrigger } from './search-trigger'
 
 interface HeaderProps {
   stars?: number | null
@@ -7,7 +8,7 @@ interface HeaderProps {
 export function Header({ stars }: HeaderProps) {
   return (
     <header className="sticky top-0 z-40 bg-background border-b border-border-light">
-      <div className="flex items-center justify-between px-6 md:px-12 py-3">
+      <div className="flex items-center justify-between pl-14 pr-6 md:px-12 py-3">
 
         {/* Left: attribution */}
         <p className="hidden sm:block font-mono text-[10px] tracking-widest text-muted-foreground">
@@ -24,8 +25,11 @@ export function Header({ stars }: HeaderProps) {
           .
         </p>
 
-        {/* Right: Node.js CTA + GitHub */}
+        {/* Right: Search + Node.js CTA + GitHub */}
         <div className="flex items-center gap-3 ml-auto">
+
+          {/* Search */}
+          <SearchTrigger />
 
           {/* Node.js CTA */}
           <a
@@ -49,9 +53,9 @@ export function Header({ stars }: HeaderProps) {
             <span>GitHub</span>
             {stars != null && (
               <>
-                <span className="w-px h-3 bg-current opacity-30" />
-                <Star size={12} strokeWidth={1.5} />
-                <span>{stars.toLocaleString()}</span>
+                <span className="hidden sm:block w-px h-3 bg-current opacity-30" />
+                <Star size={12} strokeWidth={1.5} className="hidden sm:block" />
+                <span className="hidden sm:block">{stars.toLocaleString()}</span>
               </>
             )}
           </a>

--- a/application/components/markdown-renderer.tsx
+++ b/application/components/markdown-renderer.tsx
@@ -1,14 +1,69 @@
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeSlug from 'rehype-slug'
+import rehypeRaw from 'rehype-raw'
+import { codeToHtml } from 'shiki'
 import type { Components } from 'react-markdown'
+import type { ReactNode } from 'react'
+import { CopyButton } from './copy-button'
 
 interface MarkdownRendererProps {
   content: string
   chapterSlug: string
 }
 
-export function MarkdownRenderer({ content, chapterSlug }: MarkdownRendererProps) {
+function extractText(node: ReactNode): string {
+  if (typeof node === 'string') return node
+  if (typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(extractText).join('')
+  if (node && typeof node === 'object' && 'props' in node) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return extractText((node as any).props?.children)
+  }
+  return ''
+}
+
+// Pre-process markdown: replace fenced code blocks with highlighted HTML
+async function highlightCodeBlocks(markdown: string): Promise<string> {
+  const fenceRe = /^```(\w*)\n([\s\S]*?)^```/gm
+  const blocks: Array<{ placeholder: string; replacement: string }> = []
+
+  let match: RegExpExecArray | null
+  while ((match = fenceRe.exec(markdown)) !== null) {
+    const lang = match[1] || 'text'
+    const code = match[2].replace(/\n$/, '')
+    const placeholder = `%%SHIKI_BLOCK_${blocks.length}%%`
+
+    try {
+      const html = await codeToHtml(code, {
+        lang,
+        theme: 'github-light',
+      })
+      // Wrap in a div we can detect; strip shiki's outer <pre> wrapper for our own styling
+      blocks.push({ placeholder, replacement: `<div data-shiki>${html}</div>` })
+    } catch {
+      // Unknown language — fallback to plain code block
+      blocks.push({ placeholder, replacement: match[0] })
+    }
+  }
+
+  // Replace all fenced blocks with placeholders, then swap in real HTML
+  let blockIndex = 0
+  let result = markdown.replace(fenceRe, () => {
+    return blocks[blockIndex++].placeholder
+  })
+
+  for (const b of blocks) {
+    result = result.replace(b.placeholder, b.replacement)
+  }
+
+  // Put back placeholders that weren't consumed (shouldn't happen)
+  return result
+}
+
+export async function MarkdownRenderer({ content, chapterSlug }: MarkdownRendererProps) {
+  const processedContent = await highlightCodeBlocks(content)
+
   const components: Components = {
     h1: ({ children, ...props }) => (
       <h1 className="font-heading text-4xl md:text-5xl font-black tracking-tight mt-12 mb-6 leading-tight" {...props}>
@@ -46,11 +101,40 @@ export function MarkdownRenderer({ content, chapterSlug }: MarkdownRendererProps
     li: ({ children }) => (
       <li className="leading-relaxed">{children}</li>
     ),
-    pre: ({ children }) => (
-      <pre className="mb-6 overflow-x-auto bg-[#fafafa] border border-border-light border-l-[3px] border-l-accent p-5 font-mono text-sm leading-7">
-        {children}
-      </pre>
-    ),
+    // Shiki-highlighted blocks arrive as <div data-shiki><pre class="shiki">...</pre></div>
+    // We detect them by checking if the div has a data-shiki attribute
+    div: ({ children, ...props }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const isShiki = (props as any)['data-shiki'] !== undefined
+      if (isShiki) {
+        const rawText = extractText(children)
+        return (
+          <div className="relative mb-6">
+            <CopyButton text={rawText} />
+            <div className="overflow-x-auto bg-[#fafafa] border border-border-light border-l-[3px] border-l-accent px-5 pb-5 pt-10 shiki-wrapper">
+              {children}
+            </div>
+          </div>
+        )
+      }
+      return <div {...props}>{children}</div>
+    },
+    pre: ({ children, className }) => {
+      // Shiki-generated pre — parent div renderer already wrapped it
+      if (className?.includes('shiki')) {
+        return <pre className={className}>{children}</pre>
+      }
+      // Fallback plain code block (Shiki failed or no language specified)
+      const rawText = extractText(children)
+      return (
+        <div className="relative mb-6">
+          <CopyButton text={rawText} />
+          <pre className="overflow-x-auto bg-[#fafafa] border border-border-light border-l-[3px] border-l-accent p-5 font-mono text-sm leading-7 pt-10">
+            {children}
+          </pre>
+        </div>
+      )
+    },
     code: ({ className, children, ...props }) => {
       const isBlock = className?.startsWith('language-')
       if (isBlock) {
@@ -132,10 +216,10 @@ export function MarkdownRenderer({ content, chapterSlug }: MarkdownRendererProps
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeSlug]}
+      rehypePlugins={[rehypeSlug, rehypeRaw]}
       components={components}
     >
-      {content}
+      {processedContent}
     </ReactMarkdown>
   )
 }

--- a/application/components/reading-progress.tsx
+++ b/application/components/reading-progress.tsx
@@ -1,0 +1,28 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export function ReadingProgress() {
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    function onScroll() {
+      const el = document.documentElement
+      const scrolled = el.scrollTop
+      const total = el.scrollHeight - el.clientHeight
+      setProgress(total > 0 ? (scrolled / total) * 100 : 0)
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  return (
+    <div
+      className="fixed top-0 left-0 z-50 h-[2px] bg-accent transition-none"
+      style={{ width: `${progress}%` }}
+      role="progressbar"
+      aria-valuenow={Math.round(progress)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    />
+  )
+}

--- a/application/components/search-modal.tsx
+++ b/application/components/search-modal.tsx
@@ -1,0 +1,146 @@
+'use client'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import Fuse from 'fuse.js'
+
+interface SearchEntry {
+  slug: string
+  title: string
+  number: string
+  seasonLabel: string
+}
+
+interface SearchModalProps {
+  onClose: () => void
+}
+
+export function SearchModal({ onClose }: SearchModalProps) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchEntry[]>([])
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [fuse, setFuse] = useState<Fuse<SearchEntry> | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const router = useRouter()
+
+  useEffect(() => {
+    fetch('/search-index.json')
+      .then((r) => r.json())
+      .then((data: SearchEntry[]) => {
+        setFuse(
+          new Fuse(data, {
+            keys: ['title', 'number', 'seasonLabel'],
+            threshold: 0.35,
+            includeScore: true,
+          })
+        )
+        setResults(data.slice(0, 8))
+      })
+  }, [])
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    if (!fuse) return
+    if (!query.trim()) {
+      fetch('/search-index.json')
+        .then((r) => r.json())
+        .then((data: SearchEntry[]) => setResults(data.slice(0, 8)))
+      return
+    }
+    const hits = fuse.search(query).map((r) => r.item)
+    setResults(hits.slice(0, 8))
+    setActiveIndex(0)
+  }, [query, fuse])
+
+  const navigate = useCallback(
+    (slug: string) => {
+      router.push(`/chapters/${slug}`)
+      onClose()
+    },
+    [router, onClose]
+  )
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Escape') {
+      onClose()
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveIndex((i) => Math.min(i + 1, results.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveIndex((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter' && results[activeIndex]) {
+      navigate(results[activeIndex].slug)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-24 px-4"
+      onClick={onClose}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-foreground/40" />
+
+      <div
+        className="relative w-full max-w-xl border-2 border-foreground bg-background"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Input */}
+        <div className="flex items-center border-b border-border-light">
+          <span className="pl-4 font-mono text-xs text-muted-foreground select-none">/</span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search episodes and concepts..."
+            className="w-full px-3 py-3 font-mono text-sm bg-transparent outline-none placeholder:text-muted-foreground"
+          />
+          <button
+            onClick={onClose}
+            className="px-4 py-3 font-mono text-xs text-muted-foreground hover:text-foreground"
+          >
+            ESC
+          </button>
+        </div>
+
+        {/* Results */}
+        {results.length > 0 && (
+          <ul>
+            {results.map((item, i) => (
+              <li key={item.slug}>
+                <button
+                  className={`w-full flex items-center justify-between px-4 py-2.5 text-left transition-colors duration-75 ${
+                    i === activeIndex
+                      ? 'bg-foreground text-background'
+                      : 'hover:bg-muted'
+                  }`}
+                  onClick={() => navigate(item.slug)}
+                  onMouseEnter={() => setActiveIndex(i)}
+                >
+                  <span className="font-mono text-xs tracking-widest uppercase text-current opacity-60 w-20 shrink-0">
+                    {item.number}
+                  </span>
+                  <span className="flex-1 font-body text-sm truncate">{item.title}</span>
+                  <span className="font-mono text-[10px] tracking-widest text-current opacity-50 ml-3 shrink-0">
+                    {item.seasonLabel}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {query && results.length === 0 && (
+          <p className="px-4 py-6 font-mono text-xs text-muted-foreground text-center">
+            No results for &ldquo;{query}&rdquo;
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/application/components/search-trigger.tsx
+++ b/application/components/search-trigger.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { Search } from 'lucide-react'
+import { SearchModal } from './search-modal'
+
+export function SearchTrigger() {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === '/' && !(e.target instanceof HTMLInputElement) && !(e.target instanceof HTMLTextAreaElement)) {
+        e.preventDefault()
+        setOpen(true)
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-2 px-3 py-1.5 text-xs font-mono tracking-wide border border-foreground hover:bg-foreground hover:text-background transition-colors duration-100"
+        aria-label="Search"
+      >
+        <Search size={13} strokeWidth={1.5} />
+        <span className="hidden sm:inline text-muted-foreground">/</span>
+      </button>
+      {open && <SearchModal onClose={() => setOpen(false)} />}
+    </>
+  )
+}

--- a/application/components/sidebar-client.tsx
+++ b/application/components/sidebar-client.tsx
@@ -91,6 +91,23 @@ export function SidebarClient({ seasons }: SidebarClientProps) {
           </div>
         ))}
       </nav>
+
+      {/* Attribution footer */}
+      <div className="shrink-0 px-6 py-4 border-t border-border-light">
+        <p className="font-mono text-[10px] tracking-widest text-muted-foreground leading-relaxed">
+          Based on Namaste JS by Akshay Saini.{' '}
+          Docs by{' '}
+          <a
+            href="https://github.com/akshadjaiswal"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="author-link"
+          >
+            Akshad Jaiswal
+          </a>
+          .
+        </p>
+      </div>
     </div>
   )
 

--- a/application/lib/chapters.ts
+++ b/application/lib/chapters.ts
@@ -73,9 +73,15 @@ function getAllChapterDirs(): string[] {
     })
 }
 
+function computeReadTime(content: string): number {
+  const words = content.trim().split(/\s+/).length
+  return Math.max(1, Math.ceil(words / 200))
+}
+
 function extractHeadings(markdown: string): TocHeading[] {
   const headings: TocHeading[] = []
   const lines = markdown.split('\n')
+  const slugCount = new Map<string, number>()
 
   for (const line of lines) {
     const match = line.match(/^(#{2,4})\s+(.+?)\s*$/)
@@ -88,11 +94,12 @@ function extractHeadings(markdown: string): TocHeading[] {
       .replace(/\[([^\]]+)\]\([^)]*\)?/g, '$1')
       .trim()
 
-    headings.push({
-      text,
-      slug: slugify(text),
-      level,
-    })
+    const base = slugify(text)
+    const count = slugCount.get(base) ?? 0
+    slugCount.set(base, count + 1)
+    const slug = count === 0 ? base : `${base}-${count}`
+
+    headings.push({ text, slug, level })
   }
 
   return headings
@@ -167,6 +174,7 @@ export function getChapterBySlug(slug: string): Chapter | null {
       seasonLabel: 'Concepts',
       content,
       headings: extractHeadings(content),
+      readTime: computeReadTime(content),
     }
   }
 
@@ -190,7 +198,17 @@ export function getChapterBySlug(slug: string): Chapter | null {
     seasonLabel: parsed.season === 1 ? 'Season 1' : 'Season 2',
     content,
     headings: extractHeadings(content),
+    readTime: computeReadTime(content),
   }
+}
+
+export function getSearchIndex() {
+  return getAllChapters().map((ch) => ({
+    slug: ch.slug,
+    title: ch.title,
+    number: ch.number,
+    seasonLabel: ch.seasonLabel,
+  }))
 }
 
 export function getSeasons(): Season[] {

--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -8,14 +8,18 @@
       "name": "namaste-javascript",
       "version": "0.1.0",
       "dependencies": {
+        "@shikijs/rehype": "^4.0.1",
         "clsx": "^2.1.0",
+        "fuse.js": "^7.1.0",
         "lucide-react": "^0.460.0",
         "next": "^16.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
+        "rehype-raw": "^7.0.0",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
+        "shiki": "^4.0.1",
         "tailwind-merge": "^2.5.0"
       },
       "devDependencies": {
@@ -728,6 +732,123 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.1.tgz",
+      "integrity": "sha512-vWvqi9JNgz1dRL9Nvog5wtx7RuNkf7MEPl2mU/cyUUxJeH1CAr3t+81h8zO8zs7DK6cKLMoU9TvukWIDjP4Lzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.1",
+        "@shikijs/types": "4.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.1.tgz",
+      "integrity": "sha512-DJK9NiwtGYqMuKCRO4Ip0FKNDQpmaiS+K5bFjJ7DWFn4zHueDWgaUG8kAofkrnXF6zPPYYQY7J5FYVW9MbZyBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.1.tgz",
+      "integrity": "sha512-oCWdCTDch3J8Kc0OZJ98KuUPC02O1VqIE3W/e2uvrHqTxYRR21RGEJMtchrgrxhsoJJCzmIciKsqG+q/yD+Cxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.1.tgz",
+      "integrity": "sha512-v/mluaybWdnGJR4GqAR6zh8qAZohW9k+cGYT28Y7M8+jLbC0l4yG085O1A+WkseHTn+awd+P3UBymb2+MXFc8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.1.tgz",
+      "integrity": "sha512-ns0hHZc5eWZuvuIEJz2pTx3Qecz0aRVYumVQJ8JgWY2tq/dH8WxdcVM49Fc2NsHEILNIT6vfdW9MF26RANWiTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/rehype": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-4.0.1.tgz",
+      "integrity": "sha512-bx7bYA0/p/pgeEICaPO0jT6TXrXHmr9tGRUDhOMy1cAUN2YA0iANfXX7seBnImy8DGu/rxm1ij9/ZofYrAaUjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.1",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-string": "^3.0.1",
+        "shiki": "4.0.1",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.1.tgz",
+      "integrity": "sha512-FW41C/D6j/yKQkzVdjrRPiJCtgeDaYRJFEyCKFCINuRJRj9WcmubhP4KQHPZ4+9eT87jruSrYPyoblNRyDFzvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.1.tgz",
+      "integrity": "sha512-EaygPEn57+jJ76mw+nTLvIpJMAcMPokFbrF8lufsZP7Ukk+ToJYEcswN1G0e49nUZAq7aCQtoeW219A8HK1ZOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1230,6 +1351,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1360,6 +1493,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -1392,6 +1534,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-heading-rank": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
@@ -1399,6 +1561,67 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1432,6 +1655,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-string": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
@@ -1458,6 +1700,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -1466,6 +1725,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/inline-style-parser": {
@@ -2663,6 +2932,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
+      "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -2687,6 +2973,18 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
@@ -3002,6 +3300,45 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-slug": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
@@ -3203,6 +3540,25 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.1.tgz",
+      "integrity": "sha512-EkAEhDTN5WhpoQFXFw79OHIrSAfHhlImeCdSyg4u4XvrpxKEmdo/9x/HWSowujAnUrFsGOwWiE58a6GVentMnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.1",
+        "@shikijs/engine-javascript": "4.0.1",
+        "@shikijs/engine-oniguruma": "4.0.1",
+        "@shikijs/langs": "4.0.1",
+        "@shikijs/themes": "4.0.1",
+        "@shikijs/types": "4.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/source-map-js": {
@@ -3641,6 +3997,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -3653,6 +4023,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/zwitch": {

--- a/application/package.json
+++ b/application/package.json
@@ -4,19 +4,24 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/generate-search-index.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
   },
   "dependencies": {
+    "@shikijs/rehype": "^4.0.1",
     "clsx": "^2.1.0",
+    "fuse.js": "^7.1.0",
     "lucide-react": "^0.460.0",
     "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
+    "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "shiki": "^4.0.1",
     "tailwind-merge": "^2.5.0"
   },
   "devDependencies": {

--- a/application/public/search-index.json
+++ b/application/public/search-index.json
@@ -1,0 +1,158 @@
+[
+  {
+    "slug": "s1-ep01-execution-context",
+    "title": "Execution Context",
+    "number": "EP 01",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep02-execution-and-call-stack",
+    "title": "Execution and Call Stack",
+    "number": "EP 02",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep03-hoisting",
+    "title": "Hoisting",
+    "number": "EP 03",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep04-functions-and-variable-environments",
+    "title": "Functions and Variable Environments",
+    "number": "EP 04",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep05-shortest-js-program-window-and-this-keyword",
+    "title": "Shortest JS Program, Window and this Keyword",
+    "number": "EP 05",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep06-undefined-vs-not-defined",
+    "title": "Undefined vs Not Defined",
+    "number": "EP 06",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep07-scope-and-lexical-environment",
+    "title": "Scope and Lexical Environment",
+    "number": "EP 07",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep08-let-const-and-temporal-dead-zone",
+    "title": "let const and Temporal Dead Zone",
+    "number": "EP 08",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep09-block-scope-and-shadowing",
+    "title": "Block Scope and Shadowing",
+    "number": "EP 09",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep10-closures",
+    "title": "Closures",
+    "number": "EP 10",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep11-settimeout-and-closures",
+    "title": "setTimeout and Closures",
+    "number": "EP 11",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep12-closures-interview-questions",
+    "title": "Closures Interview Questions",
+    "number": "EP 12",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep13-first-class-and-anonymous-functions",
+    "title": "First Class and Anonymous Functions",
+    "number": "EP 13",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep14-callbacks-and-event-listeners",
+    "title": "Callbacks and Event Listeners",
+    "number": "EP 14",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep15-asynchronous-js-and-event-loops",
+    "title": "Asynchronous JS and Event Loops",
+    "number": "EP 15",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep16-js-engine-and-v8-architecture",
+    "title": "JS Engine and V8 Architecture",
+    "number": "EP 16",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep17-trust-issues-with-settimeout",
+    "title": "Trust Issues with setTimeout",
+    "number": "EP 17",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep18-higher-order-functions-and-functional-programming",
+    "title": "Higher Order Functions and Functional Programming",
+    "number": "EP 18",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s1-ep19-map-filter-and-reduce",
+    "title": "map filter and reduce",
+    "number": "EP 19",
+    "seasonLabel": "Season 1"
+  },
+  {
+    "slug": "s2-ep01-callback-hell",
+    "title": "Callback Hell",
+    "number": "S2 EP 01",
+    "seasonLabel": "Season 2"
+  },
+  {
+    "slug": "s2-ep02-promises",
+    "title": "Promises",
+    "number": "S2 EP 02",
+    "seasonLabel": "Season 2"
+  },
+  {
+    "slug": "s2-ep03-promise-chaining-and-error-handling",
+    "title": "Promise Chaining and Error Handling",
+    "number": "S2 EP 03",
+    "seasonLabel": "Season 2"
+  },
+  {
+    "slug": "s2-ep04-async-await",
+    "title": "async await",
+    "number": "S2 EP 04",
+    "seasonLabel": "Season 2"
+  },
+  {
+    "slug": "s2-ep05-this-keyword-in-javascript",
+    "title": "this Keyword in JavaScript",
+    "number": "S2 EP 05",
+    "seasonLabel": "Season 2"
+  },
+  {
+    "slug": "concepts-debouncing",
+    "title": "Debouncing",
+    "number": "Concept",
+    "seasonLabel": "Concepts"
+  },
+  {
+    "slug": "concepts-throtling",
+    "title": "Throttling",
+    "number": "Concept",
+    "seasonLabel": "Concepts"
+  }
+]

--- a/application/scripts/generate-search-index.mjs
+++ b/application/scripts/generate-search-index.mjs
@@ -1,0 +1,80 @@
+// @ts-check
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CONTENT_ROOT = path.join(__dirname, '..', '..')
+
+const CHAPTER_DIR_RE = /^Chapter\s+(S(\d)\s+)?(\d+)\s*[-–]\s*(.+)$/
+const CONCEPT_TITLE_MAP = { Debouncing: 'Debouncing', Throtling: 'Throttling' }
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/<[^>]*>/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+function parseDirName(dirName) {
+  const match = dirName.match(CHAPTER_DIR_RE)
+  if (!match) return null
+  return {
+    season: match[2] ? parseInt(match[2]) : 1,
+    number: match[3],
+    title: match[4].trim(),
+  }
+}
+
+const entries = fs.readdirSync(CONTENT_ROOT, { withFileTypes: true })
+const chapterDirs = entries
+  .filter((e) => e.isDirectory() && CHAPTER_DIR_RE.test(e.name))
+  .map((e) => e.name)
+  .sort((a, b) => {
+    const pa = parseDirName(a)
+    const pb = parseDirName(b)
+    if (!pa || !pb) return a.localeCompare(b)
+    if (pa.season !== pb.season) return pa.season - pb.season
+    return parseInt(pa.number) - parseInt(pb.number)
+  })
+
+const index = []
+
+for (const dirName of chapterDirs) {
+  const parsed = parseDirName(dirName)
+  if (!parsed) continue
+  const num = parsed.number.padStart(2, '0')
+  const prefix = parsed.season === 1 ? `s1-ep${num}` : `s2-ep${num}`
+  const slug = `${prefix}-${slugify(parsed.title)}`
+  const number = parsed.season === 1 ? `EP ${num}` : `S2 EP ${num}`
+  index.push({
+    slug,
+    title: parsed.title,
+    number,
+    seasonLabel: parsed.season === 1 ? 'Season 1' : 'Season 2',
+  })
+}
+
+// Concepts
+const conceptsDir = path.join(CONTENT_ROOT, 'Concepts')
+if (fs.existsSync(conceptsDir)) {
+  const conceptEntries = fs.readdirSync(conceptsDir, { withFileTypes: true })
+  for (const e of conceptEntries) {
+    if (!e.isDirectory()) continue
+    const displayTitle = CONCEPT_TITLE_MAP[e.name] ?? e.name
+    index.push({
+      slug: `concepts-${e.name.toLowerCase()}`,
+      title: displayTitle,
+      number: 'Concept',
+      seasonLabel: 'Concepts',
+    })
+  }
+}
+
+const outPath = path.join(__dirname, '..', 'public', 'search-index.json')
+fs.writeFileSync(outPath, JSON.stringify(index, null, 2))
+console.log(`✓ search-index.json written (${index.length} entries)`)

--- a/application/types/chapter.ts
+++ b/application/types/chapter.ts
@@ -13,9 +13,10 @@ export interface Chapter {
   seasonLabel: string
   content: string
   headings: TocHeading[]
+  readTime: number
 }
 
-export type ChapterMeta = Omit<Chapter, 'content' | 'headings'>
+export type ChapterMeta = Omit<Chapter, 'content' | 'headings' | 'readTime'>
 
 export interface Season {
   number: 1 | 2 | 3


### PR DESCRIPTION
Introduce client-side search and reading UX plus Shiki-based code highlighting. Added components: CopyButton, ReadingProgress, SearchModal, and SearchTrigger; wired SearchTrigger into the header and render SearchModal on demand with Fuse.js-backed fuzzy search. MarkdownRenderer is now an async RSC pre-processing fenced code blocks with Shiki (codeToHtml) and uses rehype-raw to pass highlighted HTML through; code blocks get a copy button and consistent .shiki styling added to globals.css. lib/chapters.ts now computes and exposes readTime and adds getSearchIndex(); scripts/generate-search-index.mjs writes public/search-index.json and package.json prebuild runs that script so the JSON is available at build time. Updated chapter page to show readTime and mount ReadingProgress on chapter pages; types and documentation (CLAUDE.md) were updated to describe the new behavior and tooling.